### PR TITLE
Fix roadrunner client template hardcoding tcp-client on UDP servers

### DIFF
--- a/roles/openvpn/molecule/server_with_client/tests/test_server.py
+++ b/roles/openvpn/molecule/server_with_client/tests/test_server.py
@@ -33,6 +33,22 @@ def test_files(host, get_vars):
         assert f.is_file
 
 
+def test_client_ovpn_template_proto(host, get_vars):
+    """Client template must match server transport protocol."""
+    _defaults = get_vars.get("openvpn_defaults_server")
+    _configure = get_vars.get("openvpn_server")
+    data = merge_two_dicts(_defaults, _configure)
+
+    proto = data.get("proto", "udp")
+    template = host.file("/etc/openvpn/client.ovpn.template").content_string
+
+    if proto == "tcp":
+        assert "proto           tcp-client" in template
+    else:
+        assert "proto           udp" in template
+        assert "proto           tcp-client" not in template
+
+
 def test_user(host, get_vars):
     """ """
     _defaults = get_vars.get("openvpn_defaults_server")

--- a/roles/openvpn/templates/openvpn/client_users/client.ovpn.template.j2
+++ b/roles/openvpn/templates/openvpn/client_users/client.ovpn.template.j2
@@ -14,7 +14,11 @@ client
 
 remote          {{ external_ip }} {{ openvpn_server.port }} {{ openvpn_server.proto }}
 
+{% if openvpn_server.proto == 'tcp' %}
 proto           tcp-client
+{% else %}
+proto           udp
+{% endif %}
 dev             {{ openvpn_server.device }}
 
 remote-cert-tls server


### PR DESCRIPTION
## Problem
The roadrunner client template (`roles/openvpn/templates/openvpn/client_users/client.ovpn.template.j2`) always rendered: `proto tcp-client` regardless of `openvpn_server.proto`.

At the same time, the `remote` line correctly used the configured server protocol: `remote {{ external_ip }} {{ openvpn_server.port }} {{ openvpn_server.proto }}`

For the default UDP setup (`openvpn_server.proto: udp`), generated `.ovpn` files therefore contained conflicting directives, e.g.: `remote 203.0.113.1 1194 udp proto tcp-client`

This can cause connection failures or inconsistent client behaviour, because the OpenVPN server listens on UDP while the client config suggests TCP.

## Fix

Make the client `proto` directive follow `openvpn_server.proto`:

- `udp` => `proto udp`
- `tcp` => `proto tcp-client`

## Why this approach

- Matches OpenVPN client/server expectations for each transport mode.
- Keeps existing TCP behaviour unchanged.
- Aligns the client template with the already dynamic `remote` line.

## Test

Added a molecule test in `server_with_client/tests/test_server.py` that verifies the deployed `/etc/openvpn/client.ovpn.template` contains the expected `proto` value for the configured server transport.

## How to verify manually

1. Configure a UDP OpenVPN server via the role.
2. Generate a roadrunner client profile.
3. Confirm the resulting `.ovpn` contains `proto udp` and not `proto tcp-client`.
